### PR TITLE
package[-lock].json: Update swagger-test-templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-node",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -762,9 +762,9 @@
       }
     },
     "clone": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.0.0.tgz",
-      "integrity": "sha1-32XTyhQuSkpH2zPaNGjQiKFvx24="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "co": {
       "version": "4.6.0",
@@ -2332,9 +2332,9 @@
       }
     },
     "handlebars": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
+      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -2989,17 +2989,17 @@
       }
     },
     "json-schema-deref-sync": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.3.4.tgz",
-      "integrity": "sha512-4Ssj+1UGDJAzPIdTL1QW/rvHwWeuwC28gjbA0EjStLxVsalc+UPciKXxs3rhtr4gaGdIBojW/VmvC8B8bCQwcA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.6.0.tgz",
+      "integrity": "sha512-0efemmp3LWItb3Nux9gsoDA0xpzWaCDwoUuECEBOZQaTjAGqTrGkrJQwaIHAOD+X0SJnY+1dpsd2yE4EO+ZzRg==",
       "requires": {
-        "clone": "~2.0.0",
+        "clone": "^2.1.2",
         "dag-map": "~1.0.0",
         "is-valid-path": "^0.1.1",
-        "lodash": "^4.7.0",
+        "lodash": "^4.17.11",
         "md5": "~2.2.0",
-        "memory-cache": "~0.1.5",
-        "mpath": "~0.2.1",
+        "memory-cache": "~0.2.0",
+        "mpath": "~0.5.0",
         "traverse": "~0.6.6",
         "valid-url": "~1.0.9"
       }
@@ -3512,9 +3512,9 @@
       }
     },
     "memory-cache": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.1.6.tgz",
-      "integrity": "sha1-LtmTPteoxxgkm+c2b3yodJrPiiQ="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -3691,9 +3691,9 @@
       "dev": true
     },
     "mpath": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz",
-      "integrity": "sha1-Ok6Ck1mAHeljCcJ6ay4QLon56W4="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.2.tgz",
+      "integrity": "sha512-NOeCoW6AYc3hLi30npe7uzbD9b4FQZKH40YKABUCCvaKKL5agj6YzvHoNx8jQpDMNPgIa5bvSZQbQpWBAVD0Kw=="
     },
     "ms": {
       "version": "2.0.0",
@@ -3750,9 +3750,9 @@
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "neo-async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "next-tick": {
       "version": "1.0.0",
@@ -4937,9 +4937,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-filename": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
-      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
       }
@@ -5583,22 +5583,22 @@
       }
     },
     "swagger-test-templates": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/swagger-test-templates/-/swagger-test-templates-1.5.1.tgz",
-      "integrity": "sha512-p5EotTsyVunfNGvIr07r33Tij5p4r1aUv7QFvYYW3iO6pEUo2OXxINufkx8jBjD4/4hvP2ZlCjgLDexT2ClnGw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/swagger-test-templates/-/swagger-test-templates-1.6.0.tgz",
+      "integrity": "sha512-yWlUYlxT6FjVSvWJbHCMnAAAShSYdGvk1V1hd78Huey08Ra1Vzl8kIhhdExQ5+oLVzMrQE/FIm8fOtNjRXQqjA==",
       "requires": {
         "handlebars": "^4.0.5",
         "js-string-escape": "^1.0.1",
-        "json-schema-deref-sync": "^0.3.1",
-        "lodash": "^3.10.0",
+        "json-schema-deref-sync": "^0.6.0",
+        "lodash": "^4.17.12",
         "sanitize-filename": "^1.3.0",
         "string": "^3.3.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
     },
@@ -5903,19 +5903,19 @@
       "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
     },
     "uglify-js": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.2.tgz",
-      "integrity": "sha512-imog1WIsi9Yb56yRt5TfYVxGmnWs3WSGU73ieSOlMVFwhJCA9W8fqFFMMj4kgDqiS/80LGdsYnWL7O9UcjEBlg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.2.tgz",
+      "integrity": "sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==",
       "optional": true,
       "requires": {
-        "commander": "~2.19.0",
+        "commander": "2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "optional": true
         },
         "source-map": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "serve-static": "^1.13.2",
     "swagger-converter": "1.5.1",
     "swagger-editor": "~3.6.35",
-    "swagger-test-templates": "1.5.1",
+    "swagger-test-templates": "1.6.0",
     "swagger-tools": "0.10.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi, as mentioned in [a comment](https://github.com/multivacplatform/swagger-node/pull/2#issuecomment-542343913) in the previous PR, I bumped dependencies over at [`swagger-test-templates`](https://github.com/apigee-127/swagger-test-templates/commits/master).

By using this latest version of `swagger-test-templates` (1.6.0), people who add this package (`swagger-node`) in their projects will only have one remaining audit warning against it.

---

(dependencies I bumped over at `swagger-test-templates` were "`lodash`" and "`json-schema-deref-sync` --> `mpath`")